### PR TITLE
remove ascidoctor-rouge gem since it's included into latest ascidocto…

### DIFF
--- a/src/docker/alpine-ext/ext-asciidoctor.df
+++ b/src/docker/alpine-ext/ext-asciidoctor.df
@@ -1,7 +1,7 @@
 FROM ext-alpine AS main
 
 RUN apk --no-cache add asciidoctor \
- && gem install coderay asciidoctor-rouge --no-document \
+ && gem install coderay --no-document \
  && find /tmp -mindepth 1 -maxdepth 1 | xargs rm -rf
 
 

--- a/src/docker/debian-ext/Dockerfile
+++ b/src/docker/debian-ext/Dockerfile
@@ -42,7 +42,7 @@ RUN true \
  #
  # Install Asciidoctor
  && DEBIAN_FRONTEND=noninteractive apt install -y ruby \
- && gem install asciidoctor coderay asciidoctor-rouge --no-document \
+ && gem install asciidoctor coderay --no-document \
  #
  # Cleaning up
  && apt remove -y curl gnupg apt-transport-https lsb-release python3-pip python3-setuptools python3-wheel \

--- a/src/docker/ubuntu-ext/Dockerfile
+++ b/src/docker/ubuntu-ext/Dockerfile
@@ -42,7 +42,7 @@ RUN true \
  #
  # Install Asciidoctor
  && DEBIAN_FRONTEND=noninteractive apt install -y ruby \
- && gem install asciidoctor coderay asciidoctor-rouge --no-document \
+ && gem install asciidoctor coderay --no-document \
  #
  # Cleaning up
  && apt remove -y curl gnupg apt-transport-https lsb-release python3-pip python3-setuptools python3-wheel \


### PR DESCRIPTION
remove ascidoctor-rouge dependency since it's included directly into ascidoctor latest releases since version 2.0.0 as per https://github.com/asciidoctor/asciidoctor/blob/main/CHANGELOG.adoc#200-2019-03-22---mojavelinux